### PR TITLE
Update streamingk_com.py

### DIFF
--- a/plugin.video.vstream/resources/sites/streamingk_com.py
+++ b/plugin.video.vstream/resources/sites/streamingk_com.py
@@ -131,7 +131,8 @@ def showMovies(sSearch = ''):
 
     oRequestHandler = cRequestHandler(sUrl)
     sHtmlContent = oRequestHandler.request()
-    
+    #Meilleure resolution sthumbnail
+    sHtmlContent = sHtmlContent.replace('119x125','125x160')
     #fh = open('c:\\test.txt', "w")
     #fh.write(sHtmlContent)
     #fh.close()


### PR DESCRIPTION
Amélioration de la résolution des affiches films/séries par défaut à 119x125 ( on a pas toute l,image entière, pourquoi s'en priver xD)).
Si la résolution de l;'affiche est 119x125 , systématiquement on aura la résolution 125x160 disponible.
J'ai bien vérifié sur le site, pas trouvé d'exception. 
Ya quelques rares images ( anciens films/séries) n'étant pas en 119x125 par défaut, qui ne seront pas affectés donc par ce changement.